### PR TITLE
Add automatic generation of ssh key and hosts

### DIFF
--- a/benchmarks/hotrod-benchmark.yaml.j2
+++ b/benchmarks/hotrod-benchmark.yaml.j2
@@ -9,6 +9,9 @@ agents:
 {% for agent in groups[hyperfoil_agent_group] %}
   {{ agent }}:
     name: "{{ hostvars[agent]['inventory_hostname'] }}:{{ hyperfoil_agent_port }}"
+    {% if ssh_key is defined %}
+    sshKey: "{{ ssh_key }}"
+    {% endif %}
     extras: "{{ java_options | default(agent_java_args | default('')) }}"
 {% endfor %}
 phases:

--- a/roles/hyperfoil_agent/defaults/main.yml
+++ b/roles/hyperfoil_agent/defaults/main.yml
@@ -4,13 +4,18 @@ test_name: hotrod-benchmark
 # Note this is replaced in the benchmark file itself, see the benchmarks directory in the root
 agent_java_args: "{{ undef() }}"
 
+# This defines what ssh key will be copied from the Controller .ssh directory
+# to the authorized keys on each agent. Also the controller will add
+# a known_hosts entry for each agent
+ssh_key: "{{ undef() }}"
+
 # The rest are all described at https://github.com/Hyperfoil/hyperfoil_test
 
-hyperfoil_controller_group: hyperofoil-controller
+hyperfoil_controller_group: hyperfoil_controller
 hyperfoil_controller_host: "{{ undef{} }}"
 hyperfoil_controller_port: "{{ undef{} }}"
 hyperfoil_controller_protocol: http
 hyperfoil_validate_certs: true
 hyperfoil_deployer: ssh
-hyperfoil_agent_group: hyperfoil-agent
+hyperfoil_agent_group: hyperfoil_agent
 hyperfoil_agent_port: 22

--- a/roles/hyperfoil_agent/tasks/init.yml
+++ b/roles/hyperfoil_agent/tasks/init.yml
@@ -2,3 +2,30 @@
   ansible.builtin.include_role:
     name: java_installer
 
+
+- name: Configure ssh authorization
+  when: ssh_key is defined
+  block:
+
+  - name: Validate that there's only single controller
+    when: (groups[hyperfoil_controller_group] | length) != 1
+    fail:
+      msg: Only one controller is allowed.
+
+  - name: Gather controller public key
+    ansible.builtin.shell: "cat $HOME/.ssh/{{ ssh_key }}.pub"
+    register: controller_public_key_contents
+    delegate_to: "{{ groups[hyperfoil_controller_group][0] }}"
+
+  - name: Add key to authorized keys on agents
+    ansible.posix.authorized_key:
+      user: "{{ ansible_user_id }}"
+      key: "{{ controller_public_key_contents.stdout_lines[0] }}"
+
+  - name: Controller add known hosts of agents
+    ansible.builtin.known_hosts:
+      name: "{{ item }}"
+      key : "{{ lookup('pipe', 'ssh-keyscan {{ item }}') }}"
+    loop: "{{ groups[hyperfoil_agent_group] }}"
+    delegate_to: "{{ groups[hyperfoil_controller_group][0] }}"
+

--- a/roles/hyperfoil_controller/defaults/main.yml
+++ b/roles/hyperfoil_controller/defaults/main.yml
@@ -1,3 +1,6 @@
+# Creates a named SSH key at $HOME/.ssh on the controller if not present
+ssh_key: "{{ undef() }}"
+
 # All of these are described at https://github.com/Hyperfoil/hyperfoil_setup
 
 hyperfoil_distribution: "{{ undef() }}"

--- a/roles/hyperfoil_controller/tasks/init.yml
+++ b/roles/hyperfoil_controller/tasks/init.yml
@@ -1,3 +1,9 @@
 - name: "Installing Java 17 on Hyperfoil Controller"
   ansible.builtin.include_role:
     name: java_installer
+
+- name: "Generate SSH key"
+  ansible.builtin.shell:
+    cmd: "ssh-keygen -f $HOME/.ssh/{{ ssh_key }} -t rsa -q -N ''"
+    creates: "$HOME/.ssh/{{ ssh_key }}"
+  when: ssh_key is defined


### PR DESCRIPTION
Allows defining a new variable named ssh_key.

Hyperfoil controller will create an SSH key in ~/.ssh of that name if not present

Hyperfoil agent(s) will do the following:

1. Copy the public key from the controller to each agent as an authorized key
2. Controller will add known_hosts entry for each agent

This will allow the controller to connect to the agents via SSH automatically.