### PR TITLE
Initial approach to run multiple benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ There are three main playbooks: server.yml (Infinispan Server), hyperfoil_contro
 * hyperfoil_agent.yml - Runs a hyperfoil jobs, requires the controller and Infinispan servers to already be running.
   * Utilizes the `test_name` variable to read a templated file with extension `yaml.j2` in the `benchmarks` directory. Default is `hotrod-benchmark`
   * The configured host group can be replaced by passing `-e hyperfoil_agent_hosts=<host1,host2>'
+* all_benchmarks.yml - Runs multiple benchmarks in sequence. The instance must be running already, the playbook start the Hyperfoil controller
+ and start/stop the server for each benchmark. A file with the benchmark definitions must be provided
+  * Run this benchmark utilizing the sample definition as `-e @benchmark_definition.json`.
+  * The `cache_file` and `test_name` should not be set.
 
 The three main playbooks directly reference the three roles of the same name. They each have default values that can be overridden via the ansible command line such as `-e cache_name=name-of-my-cache`.
 
@@ -63,6 +67,27 @@ The three main playbooks directly reference the three roles of the same name. Th
 * Server defaults are [main.yaml](roles/server/defaults/main.yml)
 * Hyperfoil Controller arguments are [main.yaml](roles/hyperfoil_controller/defaults/main.yml)
 * Hyperfoil agent arguments are [main.yaml](roles/hyperfoil_agent/defaults/main.yml)
+
+### Benchmark definitions file
+
+Running multiple tests at once with `all_benchmarks.yml` playbook requires the definition in the `benchmark` variable.
+This is provided with the option `-e @<path-to.file>`.
+Ansible is capable of handling JSON or YAML files as inputs and associate the content to variables.
+Utilizing JSON as an example, the definition should follow:
+
+```json
+{
+  "benchmarks": [
+    {
+      "name": "hyperfoil-benchmark-name",
+      "cache": "cache-file.xml"
+    }
+  ]
+}
+```
+
+The benchmark files are located on the `./benchmarks/` folder, at the project root.
+The cache files are located in `./roles/server/files/` folder.
 
 Internal Steps
 --------------

--- a/all_benchmarks.yml
+++ b/all_benchmarks.yml
@@ -1,0 +1,16 @@
+- ansible.builtin.import_playbook: hyperfoil_controller.yml
+
+- ansible.builtin.import_playbook: hyperfoil_agent.yml
+  vars:
+    operation: init
+
+- ansible.builtin.import_playbook: server.yml
+  vars:
+    operation: init
+
+- hosts: "{{ server_hosts | default('server') }}"
+  roles: [benchmark]
+
+- ansible.builtin.import_playbook: hyperfoil_controller.yml
+  vars:
+    operation: shutdown

--- a/benchmark_definition.json
+++ b/benchmark_definition.json
@@ -1,0 +1,12 @@
+{
+  "benchmarks": [
+    {
+      "name": "hotrod-benchmark",
+      "cache": "cache.xml"
+    },
+    {
+      "name": "hotrod-benchmark",
+      "cache": "repl-cache.xml"
+    }
+  ]
+}

--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -1,5 +1,3 @@
-# Name of the cache to install use on the Infinispan Server
-cache_name: benchmark
 # User that is configured on the Infinispan Server
 user: benchmark
 # Password of the user configured on the Infinispan Server

--- a/roles/benchmark/tasks/main.yml
+++ b/roles/benchmark/tasks/main.yml
@@ -1,0 +1,13 @@
+- name: Assert variables
+  when: cache_name is defined or test_name is defined
+  fail:
+    msg: "Do not set 'cache_name' or 'test_name'"
+
+- name: Run all
+  ansible.builtin.include_tasks: run.yml
+  vars:
+    cache_name: "{{ benchmark.cache }}"
+    test_name: "{{ benchmark.name }}"
+  loop: "{{ benchmarks }}"
+  loop_control:
+    loop_var: benchmark

--- a/roles/benchmark/tasks/run.yml
+++ b/roles/benchmark/tasks/run.yml
@@ -1,0 +1,20 @@
+- name: Start Infinispan server
+  ansible.builtin.include_role:
+    name: server
+  vars:
+    operation: run,create_cache
+
+- name: Run Hyperfoil agent
+  ansible.builtin.include_role:
+    name: hyperfoil_agent
+    apply:
+      delegate_to: "{{ groups['hyperfoil_agent'][0] }}"
+  run_once: true
+  vars:
+    operation: run
+
+- name: Shutdown Infinispan server
+  ansible.builtin.include_role:
+    name: server
+  vars:
+    operation: delete_cache,shutdown

--- a/roles/hyperfoil_agent/defaults/main.yml
+++ b/roles/hyperfoil_agent/defaults/main.yml
@@ -1,3 +1,5 @@
+# Name of the cache to install use on the Infinispan Server
+cache_name: benchmark
 # The default test name to find in the benchmarks directory with a prefix ending in `yaml.j2`
 test_name: hotrod-benchmark
 # The JVM arguments to provide to the agent when it starts

--- a/roles/server/defaults/main.yml
+++ b/roles/server/defaults/main.yml
@@ -1,3 +1,5 @@
+# Name of the cache to install use on the Infinispan Server
+cache_name: benchmark
 # Location of the cache configuration to use for the named cache
 cache_file: files/cache.xml
 # Optional way to override the server image used by the benchmar

--- a/roles/server/files/repl-cache.xml
+++ b/roles/server/files/repl-cache.xml
@@ -1,0 +1,9 @@
+<replicated-cache segments="256"
+                   mode="SYNC"
+                   statistics="true">
+  <encoding media-type="application/x-protostream"/>
+  <expiration lifespan="500000"
+              max-idle="100000" />
+  <memory max-count="10000"
+          when-full="REMOVE"/>
+</replicated-cache>

--- a/roles/server/tasks/cache_lifecycle.yml
+++ b/roles/server/tasks/cache_lifecycle.yml
@@ -1,9 +1,9 @@
-    - name: Add the cache
+    - name: "Manage cache {{ http_method | default('PUT') }}"
       ansible.builtin.uri:
         url: "http://0.0.0.0:11222/rest/v2/caches/{{ cache_name }}"
         url_username: "{{ user }}"
         url_password: "{{ pass }}"
-        method: PUT
+        method: "{{ http_method | default('PUT') }}"
         body: "{{ lookup('ansible.builtin.file', cache_file) }}"
         headers:
           Content-Type: application/xml

--- a/roles/server/tasks/main.yml
+++ b/roles/server/tasks/main.yml
@@ -10,8 +10,16 @@
       when: operation is undefined or operation is search("run")
 
     - name: "Creating cache"
-      ansible.builtin.include_tasks: create_cache.yml
+      ansible.builtin.include_tasks: cache_lifecycle.yml
+      vars:
+            http_method: PUT
       when: operation is undefined or operation is search("create_cache")
+
+    - name: "Delete cache"
+      ansible.builtin.include_tasks: cache_lifecycle.yml
+      vars:
+            http_method: DELETE
+      when: operation is defined and operation is search("delete_cache")
 
     - name: "Shutting down server"
       ansible.builtin.include_tasks: shutdown.yml


### PR DESCRIPTION
An initial attempt to start a discussion.

I had the idea of a file defining the possible benchmarks. This file defines which benchmark file to use, which cache definition, and custom parameters for the server. We then generate a playbook containing all the benchmarks.

I was hoping we could load the generated playbook, but it seems that Ansible does not support it. The playbook must exist when it is imported. It would need a step to generate the playbook and another to run the generated file.

Should I add a script that executes the two steps? I was afraid that it wouldn't be friendly to run later in the automation. Let me know what you think.