### PR TITLE
Make hosts for playbooks overrideable

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,14 @@ There are three main playbooks: server.yml (Infinispan Server), hyperfoil_contro
 * server.yml - Starts the Infinispan server container nodes with host networking enabled. Also uploads the `cache_name` named cache with the configuration in the `cache_file` file.
   * Default `cache_name` variable is `benchmark` and `cache_file` is `files/cache.xml` if you wish to change the name or xml file.
   * This playbook can also be ran with `-e operation=shutdown` to shutdown the inventoried servers
+  * The configured host group can be replaced by passing `-e server_hosts=<host1,host2>'
 * hyperfoil.yml - Playbook that encompasses starting the hyperfoil controler, agents and starts a run and then shuts them all down. Note the server must already be running and configured in the server hosts file.
 * hyperfoil_controller.yml - Sets up the hyperfoil controller.
   * This playbook can also be ran with `-e operation=shutdown` to shutdown the controller and agents if running
+  * The configured host group can be replaced by passing `-e hyperfoil_controller_host=<host>'
 * hyperfoil_agent.yml - Runs a hyperfoil jobs, requires the controller and Infinispan servers to already be running.
   * Utilizes the `test_name` variable to read a templated file with extension `yaml.j2` in the `benchmarks` directory. Default is `hotrod-benchmark`
+  * The configured host group can be replaced by passing `-e hyperfoil_agent_hosts=<host1,host2>'
 
 The three main playbooks directly reference the three roles of the same name. They each have default values that can be overridden via the ansible command line such as `-e cache_name=name-of-my-cache`.
 

--- a/hyperfoil_agent.yml
+++ b/hyperfoil_agent.yml
@@ -1,2 +1,2 @@
-- hosts: hyperfoil_agent
+- hosts: "{{ hyperfoil_agent_hosts | default('hyperfoil_agent') }}"
   roles: [ hyperfoil_agent ]

--- a/hyperfoil_controller.yml
+++ b/hyperfoil_controller.yml
@@ -1,2 +1,2 @@
-- hosts: hyperfoil_controller
+- hosts: "{{ hyperfoil_controller_host | default('hyperfoil_controller') }}"
   roles: [ hyperfoil_controller ]

--- a/server.yml
+++ b/server.yml
@@ -1,2 +1,2 @@
-- hosts: server
+- hosts: "{{ server_hosts | default('server') }}"
   roles: [ server ]


### PR DESCRIPTION
Note we do not change the ec2-benchmark hosts as that already sets up its host groups automatically.