### PR TITLE
Remove max idle from default cache configuration

### DIFF
--- a/roles/server/files/cache.xml
+++ b/roles/server/files/cache.xml
@@ -3,8 +3,7 @@
                    mode="SYNC"
                    statistics="true">
   <encoding media-type="application/x-protostream"/>
-  <expiration lifespan="500000"
-              max-idle="100000" />
+  <expiration lifespan="500000"/>
   <memory max-count="10000"
           when-full="REMOVE"/>
 </distributed-cache>


### PR DESCRIPTION
Max idle causes a remote touch per read command. We should not have that enabled for the default configuration.