### PR TITLE
Automate benchmark plan

### DIFF
--- a/.github/actions/benchmark-complete/action.yml
+++ b/.github/actions/benchmark-complete/action.yml
@@ -1,0 +1,29 @@
+name: Run the complete benchmark definition
+description: Run all the benchmarks in sequence
+
+inputs:
+  inventory:
+    description: 'The Ansible inventory file to use.'
+    required: true
+
+  definition:
+    description: 'The JSON file describing the benchmark plan.'
+    required: true
+
+  hyperfoil_agent_args:
+    description: 'Arguments to provide to the Hyperfoil agent.'
+    required: false
+    default: ''
+
+  server_java_args:
+    description: 'Arguments to provide to the Infinispan server.'
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - id: benchmark-run-all
+      name: Run the benchmark plan
+      shell: bash
+      run: ./benchmark.sh run -i ${{ inputs.inventory }} -e @${{ inputs.definition }} -e agent_java_args=\"'${{ inputs.hyperfoil_agent_args }}'\" -e server_java_args=\"'${{ inputs.server_java_args }}'\"

--- a/.github/actions/benchmark-reports/action.yml
+++ b/.github/actions/benchmark-reports/action.yml
@@ -1,0 +1,31 @@
+name: Download the reports
+description: Download all the benchmarks reports and upload to GitHub
+
+inputs:
+  inventory:
+    description: 'The Ansible inventory file to use.'
+    required: true
+
+  definition:
+    description: 'The JSON file describing the benchmark plan.'
+    required: true
+
+  report_folder:
+    description: 'Folder to store the reports'
+    required: false
+    default: 'reports'
+
+runs:
+  using: composite
+  steps:
+    - id: benchmark-run-all
+      name: Run the benchmark plan
+      shell: bash
+      run: ./benchmark.sh report ${{ inputs.definition }} ${{ inputs.report_folder }} -i ${{ inputs.inventory }}
+
+    - uses: actions/upload-artifact@v4
+      id: upload-to-github
+      name: Upload ${{ inputs.report_folder }} to GitHub
+      with:
+        name: ${{ inputs.report_folder }}
+        path: ${{ inputs.report_folder }}

--- a/.github/workflows/multiple.yml
+++ b/.github/workflows/multiple.yml
@@ -1,0 +1,95 @@
+name: Run a benchmark plan
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch/commit to run the benchmarks.'
+        type: string
+        default: 'main'
+
+      region:
+        description: 'Name of the region where EC2 instances should be installed'
+        type: string
+        default: 'sa-east-1'
+
+      infinispan_image:
+        description: 'Infinispan server image to utilize'
+        type: string
+        default: 'quay.io/infinispan/server'
+
+      benchmark_plan:
+        description: 'Benchmark plan to run'
+        type: string
+        default: 'benchmark_definition.json'
+
+      hyperfoil_agent_args:
+        description: 'Arguments to provide the Hyperfoil agent'
+        type: string
+        default: '-Xms128m -Xmx800m -XX:+UseZGC -XX:+ZGenerational'
+
+      aws_instances_args:
+        description: 'Arguments to provide to Ansible when provisioning the instances'
+        type: string
+        default: ''
+
+      server_args:
+        description: 'Java arguments to provide the Infinispan server.'
+        type: string
+        default: ''
+
+env:
+  ANSIBLE_HOST_KEY_CHECKING: False
+  INVENTORY_NAME: 'benchmark-file.yaml'
+
+jobs:
+  bencmark:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Create AWS EC2 instances
+        id: create_aws_ec2_instances
+        uses: ./.github/actions/ec2-create-instances
+        with:
+          region: ${{ inputs.region }}
+          arguments: ${{ inputs.aws_instances_args }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: Set inventory file name
+        run: ls -1 *_inventory.yaml | xargs -L1 -I{} cp {} $INVENTORY_NAME
+
+      - name: Start the Hyperfoil controller
+        uses: ./.github/actions/hyperfoil-create-controller
+        with:
+          inventory: $INVENTORY_NAME
+
+      - name: Run all benchmarks for image ${{ inputs.infinispan_image }}
+        uses: ./.github/actions/benchmark-complete
+        with:
+          inventory: $INVENTORY_NAME
+          definition: ${{ inputs.benchmark_plan }}
+          server_java_args: ${{ inputs.server_args }}
+          hyperfoil_agent_args: ${{ inputs.hyperfoil_agent_args }}
+
+      - name: Download all the results
+        uses: ./.github/actions/benchmark-reports
+        with:
+          inventory: $INVENTORY_NAME
+          definition: ${{ inputs.benchmark_plan }}
+          report_folder: reports
+
+      - name: Delete EC2 instances
+        if: ${{ always() && steps.create_aws_ec2_instances.conclusion != 'skipped' }}
+        uses: ./.github/actions/ec2-delete-instances
+        with:
+          region: ${{ inputs.region }}
+          inventory: $INVENTORY_NAME
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1,0 +1,20 @@
+name: Run benchmarks weekly
+
+on:
+  schedule:
+    # Run on every WED on 4:30 UTC
+    - cron: '30 4 * * 3'
+
+jobs:
+  scheduled-run:
+    name: Invoke complete default benchmark plan
+    uses: ./.github/workflows/multiple.yml
+    secrets: inherit
+    with:
+      branch: 'main'
+      region: 'us-east-1'
+      infinispan_image: 'quay.io/infinispan/server:latest'
+      benchmark_plan: 'benchmark_definition.json'
+      hyperfoil_agent_args: '-Xms128m -Xmx800m -XX:+UseZGC -XX:+ZGenerational'
+      aws_instances_args: '-e server_instance_type=t4g.small -e server_ami_name=debian-12-arm64-20231013-1532 -e agent_instance_type=t4g.micro -e agent_ami_name=al2023-ami-2023.4.20240513.0-kernel-6.1-arm64 -e controller_instance_type=t4g.micro -e controller_ami_name=al2023-ami-2023.4.20240513.0-kernel-6.1-arm64'
+      server_args: ''

--- a/all_benchmarks.yml
+++ b/all_benchmarks.yml
@@ -1,5 +1,3 @@
-- ansible.builtin.import_playbook: hyperfoil_controller.yml
-
 - ansible.builtin.import_playbook: hyperfoil_agent.yml
   vars:
     operation: init
@@ -10,7 +8,3 @@
 
 - hosts: "{{ server_hosts | default('server') }}"
   roles: [benchmark]
-
-- ansible.builtin.import_playbook: hyperfoil_controller.yml
-  vars:
-    operation: shutdown

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -e
+cd $(dirname "${BASH_SOURCE[0]}")
+
+if [[ "$RUNNER_DEBUG" == "1" ]]; then
+  set -x
+fi
+
+OPERATION=$1
+
+case $OPERATION in
+  run)
+    ansible-playbook all_benchmarks.yml -v "${@:2}"
+  ;;
+  report)
+    size=$(jq '.benchmarks | length' "$2")
+    for ((i=0;i<"$size";i++)); do
+      id=$(printf "%04x" "$i")
+      ./hyperfoil.sh stats -e test_runid="$id" -e download_results=true "${@:4}"
+    done
+
+    mkdir "$3"
+    cp ./*.csv "$3"
+    cp ./*_all.json "$3"
+  ;;
+  *)
+    echo "Invalid option! $OPERATION"
+    echo "Available operations: run,report"
+    exit 1;
+  ;;
+esac


### PR DESCRIPTION
Adds a few scripts to interact with the `all_benchmark`. I also changed the original `all_benchmark` playbook to assume a running Hyperfoil controller instance. If the playbook shutdowns the controller at the end, we can't download the reports.

I also split into two GitHub workflows. The first one we can trigger manually to run the benchmark plan, and the other runs scheduled. The latter invokes the former and passes the arguments.