### PR TITLE
Define fingerprint to distinguish runs

### DIFF
--- a/roles/benchmark/tasks/run.yml
+++ b/roles/benchmark/tasks/run.yml
@@ -17,6 +17,7 @@
   run_once: true
   vars:
     operation: run
+    hyperfoil_run_description: "{{ server_image }}-{{ cache_file }}"
 
 - name: Shutdown Infinispan server
   ansible.builtin.include_role:

--- a/roles/hyperfoil_agent/defaults/main.yml
+++ b/roles/hyperfoil_agent/defaults/main.yml
@@ -25,6 +25,11 @@ agent_java_args: "{{ undef() }}"
 # a known_hosts entry for each agent
 ssh_key: "benchmark"
 
+# Defines the description of the run on the JSON output.
+# We utilize this value to distinguish between server version and cache configuration on Horreum.
+# By default, it can be null. If running the complete test suite, it is automatically filled.
+hyperfoil_run_description: ''
+
 # The rest are all described at https://github.com/Hyperfoil/hyperfoil_test
 
 hyperfoil_controller_group: hyperfoil_controller

--- a/roles/hyperfoil_agent/tasks/run.yml
+++ b/roles/hyperfoil_agent/tasks/run.yml
@@ -1,6 +1,8 @@
 - name: Import hyperfoil test to run
   ansible.builtin.import_role:
     name: hyperfoil.hyperfoil_test
+  vars:
+    run_description: "{{ hyperfoil_run_description }}"
 
 - name: Hyperfoil test requests
   ansible.builtin.include_role:

--- a/roles/server/defaults/main.yml
+++ b/roles/server/defaults/main.yml
@@ -2,8 +2,8 @@
 cache_name: benchmark
 # Location of the cache configuration to use for the named cache
 cache_file: files/cache.xml
-# Optional way to override the server image used by the benchmar
-server_image: quay.io/infinispan/server
+# Optional way to override the server image used by the benchmark
+server_image: "quay.io/infinispan/server:15.0"
 # Java VM arguments passed to the server image when running
 server_java_args: "{{ undef() }}"
 # Allows for automatic generation of Java Flight Recorder and download


### PR DESCRIPTION
In Horreum, we utilize a fingerprint to identify which configurations should be tracked for changes. This allows us to test different configurations, with different server versions without needing to create a test for each on Horreum.

I am setting the server image to the `15.0` stream which should be the latest stable. Otherwise, it would always return `:latest` tag.