### PR TITLE
Added SIFS configuration

### DIFF
--- a/benchmark_definition.json
+++ b/benchmark_definition.json
@@ -26,6 +26,14 @@
     },
     {
       "name": "hotrod-benchmark",
+      "cache": "dist-sifs.xml",
+      "arguments": {
+        "read_ratio": 0.8,
+        "write_ratio": 0.2
+      }
+    },
+    {
+      "name": "hotrod-benchmark",
       "cache": "repl-cache.xml",
       "arguments": {
         "read_ratio": 0.8,
@@ -46,6 +54,14 @@
       "arguments": {
         "read_ratio": 0.0,
         "write_ratio": 1.0
+      }
+    },
+    {
+      "name": "hotrod-benchmark",
+      "cache": "repl-sifs.xml",
+      "arguments": {
+        "read_ratio": 0.8,
+        "write_ratio": 0.2
       }
     }
   ]

--- a/roles/server/files/dist-sifs.xml
+++ b/roles/server/files/dist-sifs.xml
@@ -1,0 +1,17 @@
+<distributed-cache owners="2"
+                   segments="256"
+                   mode="SYNC"
+                   statistics="true">
+  <encoding media-type="application/x-protostream"/>
+  <expiration lifespan="500000"/>
+
+  <!-- Max-count of 2000 to force entries to disk. -->
+  <!-- The benchmark accepts a custom number of entries, by default is 4000. -->
+  <memory max-count="1" when-full="REMOVE"/>
+  <persistence passivation="false">
+    <file-store shared="false">
+      <data path="data"/>
+      <index path="index"/>
+    </file-store>
+  </persistence>
+</distributed-cache>

--- a/roles/server/files/repl-sifs.xml
+++ b/roles/server/files/repl-sifs.xml
@@ -1,0 +1,15 @@
+<replicated-cache segments="256"
+                   mode="SYNC"
+                   statistics="true">
+  <encoding media-type="application/x-protostream"/>
+  <expiration lifespan="500000"/>
+
+  <!-- Max-count of 1 to force entries to disk. -->
+  <memory max-count="1" when-full="REMOVE"/>
+  <persistence passivation="true">
+    <file-store shared="false">
+      <data path="data"/>
+      <index path="index"/>
+    </file-store>
+  </persistence>
+</replicated-cache>


### PR DESCRIPTION
Add a configuration for DIST and REPL. TBH, I am unsure if we need to run for both modes to identify regression or if only one is enough. Also, I've set memory.max-count to a value lower than the number of entries hoping it would cause operations to go to disk.